### PR TITLE
Allow public access to calculator and examples pages

### DIFF
--- a/app/examples/page.tsx
+++ b/app/examples/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function ExamplesPage() {
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-4">Examples</h1>
+      <p className="text-muted-foreground">
+        Example scenarios will be added here.
+      </p>
+    </div>
+  );
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -52,7 +52,9 @@ export async function updateSession(request: NextRequest) {
     request.nextUrl.pathname !== "/" &&
     !user &&
     !request.nextUrl.pathname.startsWith("/login") &&
-    !request.nextUrl.pathname.startsWith("/auth")
+    !request.nextUrl.pathname.startsWith("/auth") &&
+    !request.nextUrl.pathname.startsWith("/calculator") &&
+    !request.nextUrl.pathname.startsWith("/examples")
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Summary
- permit unauthenticated users to view calculator and examples pages
- add placeholder examples page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf1c9c50832085c0f3b9064e8155